### PR TITLE
fix a cross-browser bug

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -44,7 +44,8 @@ var getComputedStyle = document.defaultView.getComputedStyle;
 
 var getScrollEventTarget = function (element) {
   var currentNode = element;
-  while (currentNode && currentNode.tagName !== 'HTML' && currentNode.nodeType === 1) {
+  // bugfix, see http://w3help.org/zh-cn/causes/SD9013 and http://stackoverflow.com/questions/17016740/onscroll-function-is-not-working-for-chrome
+  while (currentNode && currentNode.tagName !== 'HTML' && currentNode.tagName !== 'BODY' && currentNode.nodeType === 1) {
     var overflowY = getComputedStyle(currentNode).overflowY;
     if (overflowY === 'scroll' || overflowY === 'auto') {
       return currentNode;


### PR DESCRIPTION
scroll event bugfix, see http://w3help.org/zh-cn/causes/SD9013 and http://stackoverflow.com/questions/17016740/onscroll-function-is-not-working-for-chrome