### PR TITLE
fix destroyed removeEventListener bug

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -196,6 +196,7 @@ export default {
   },
 
   unbind(el) {
-    el[ctx].scrollEventTarget.removeEventListener('scroll', el[ctx].scrollListener);
+    if (el && el[ctx] && el[ctx].scrollEventTarget)
+      el[ctx].scrollEventTarget.removeEventListener('scroll', el[ctx].scrollListener);
   }
 };


### PR DESCRIPTION
TypeError: Cannot read property 'removeEventListener' of undefined
    at unbind (eval at <anonymous> (app.js:2220), <anonymous>:205:34)
    at callHook$1 (eval at <anonymous> (app.js:600), <anonymous>:4746:5)
    at _update (eval at <anonymous> (app.js:600), <anonymous>:4711:9)
    at updateDirectives (eval at <anonymous> (app.js:600), <anonymous>:4653:5)
    at Array.unbindDirectives (eval at <anonymous> (app.js:600), <anonymous>:4647:5)
    at invokeDestroyHook (eval at <anonymous> (app.js:600), <anonymous>:4291:64)
    at invokeDestroyHook (eval at <anonymous> (app.js:600), <anonymous>:4295:9)
    at VueComponent.patch [as __patch__] (eval at <anonymous> (app.js:600), <anonymous>:4557:23)
    at VueComponent.Vue.$destroy (eval at <anonymous> (app.js:600), <anonymous>:2750:8)
    at destroy$1 (eval at <anonymous> (app.js:600), <anonymous>:1780:31)
    at invokeDestroyHook (eval at <anonymous> (app.js:600), <anonymous>:4290:59)
    at removeVnodes (eval at <anonymous> (app.js:600), <anonymous>:4306:11)
    at updateChildren (eval at <anonymous> (app.js:600), <anonymous>:4413:7)
    at patchVnode (eval at <anonymous> (app.js:600), <anonymous>:4448:29)
    at VueComponent.patch [as __patch__] (eval at <anonymous> (app.js:600), <anonymous>:4572:9)
    at VueComponent.Vue._update (eval at <anonymous> (app.js:600), <anonymous>:2646:19)

destroy 时应该检测有没有该元素