### PR TITLE
Fix if use router link and component

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -186,7 +186,7 @@ export default {
       expression: binding.value
     };
     const args = arguments;
-    el[ctx].vm.$on('hook:mounted', function () {
+    el[ctx].vm.$on('hook:updated', function () {
       el[ctx].vm.$nextTick(function () {
         if (isAttached(el)) {
           doBind.call(el[ctx], args);


### PR DESCRIPTION
Hook `mounted` not work if use vue component. Change to `updated` hook will make work with component vue and without component.