### PR TITLE
Update directive.js

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -4,8 +4,8 @@ var throttle = function (fn, delay) {
   var now, lastExec, timer, context, args; //eslint-disable-line
 
   var execute = function () {
+    lastExec = Date.now();
     fn.apply(context, args);
-    lastExec = now;
   };
 
   return function () {


### PR DESCRIPTION
lastExec应该使用Date.now()，如果使用now变量，lastExec在大多数情况下会比预期要小，造成目标函数的执行间隔偶尔会小于设定的间隔