### PR TITLE
Fix expression triggering when component is inactive

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -173,7 +173,7 @@ var doCheck = function (force) {
     shouldTrigger = viewportBottom + distance >= elementBottom;
   }
 
-  if (shouldTrigger && this.expression) {
+  if (shouldTrigger && this.expression && !this.vm._inactive) {
     this.expression();
   }
 };


### PR DESCRIPTION
Previously when wrapping vue-infinite-scroll's element inside keep-alive, callback was still executed even after swapping to another keep-alive'd component and scrolling downards.

This prevents callback expression triggering when component is inactive.

Fixes #121, #125